### PR TITLE
Update payment buttons, add image lightbox, and UI fixes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,9 @@
-<div class="flex flex-col bg-gray-100 ">
+<div class="flex flex-col min-h-screen bg-gray-100 ">
   <app-header class="sticky top-0 z-50 mb-10"></app-header>
-  <router-outlet ></router-outlet>
+  <main class="flex-1">
+    <router-outlet></router-outlet>
+  </main>
   <app-footer ></app-footer>
+  <app-image-lightbox></app-image-lightbox>
 </div>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,8 @@ import { MemberDirectoryModuleLicenseComponent } from './pages/member-directory-
 import { ButtonComponent } from './components/button/button.component';
 import { MemberDirectoryInstalationGuideComponent } from './pages/module-installation-guides/member-directory-instalation-guide/member-directory-instalation-guide.component';
 import { CollapsiblePanelComponent } from './components/collapsible-panel/collapsible-panel.component';
+import { ImageLightboxComponent } from './components/image-lightbox/image-lightbox.component';
+import { ZoomableDirective } from './directives/zoomable.directive';
 
 @NgModule({
   declarations: [
@@ -26,7 +28,9 @@ import { CollapsiblePanelComponent } from './components/collapsible-panel/collap
     MemberDirectoryModuleLicenseComponent,
     ButtonComponent,
     MemberDirectoryInstalationGuideComponent,
-    CollapsiblePanelComponent
+    CollapsiblePanelComponent,
+    ImageLightboxComponent,
+    ZoomableDirective
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,6 +1,6 @@
 <footer class="bg-gray-800 text-white py-4">
     <div class="container mx-auto text-center">
-      <p>&copy; {{currentYear}} Kabinary. All Rights Reserved.</p>
+      <p>&copy; {{currentYear}} Kabinary LLC. All Rights Reserved.</p>
       <p>Contact us at <a [href]="'mailto:' + contactEmail" class="text-blue-400">{{contactEmail}}</a></p>
     </div>
 </footer>

--- a/src/app/components/image-lightbox/image-lightbox.component.html
+++ b/src/app/components/image-lightbox/image-lightbox.component.html
@@ -1,0 +1,11 @@
+<div *ngIf="state().open"
+     class="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 p-4 cursor-zoom-out"
+     (click)="close()">
+  <button type="button"
+          (click)="$event.stopPropagation(); close()"
+          class="absolute top-4 right-4 text-white text-4xl leading-none hover:opacity-70 focus:outline-none"
+          aria-label="Close">&times;</button>
+  <img [src]="state().src" [alt]="state().alt"
+       (click)="$event.stopPropagation()"
+       class="max-w-[95vw] max-h-[95vh] object-contain shadow-2xl rounded-md cursor-default">
+</div>

--- a/src/app/components/image-lightbox/image-lightbox.component.ts
+++ b/src/app/components/image-lightbox/image-lightbox.component.ts
@@ -1,0 +1,26 @@
+import { Component, HostListener } from '@angular/core';
+import { ImageLightboxService } from './image-lightbox.service';
+
+@Component({
+  selector: 'app-image-lightbox',
+  standalone: false,
+  templateUrl: './image-lightbox.component.html'
+})
+export class ImageLightboxComponent {
+  readonly state;
+
+  constructor(private readonly lightbox: ImageLightboxService) {
+    this.state = lightbox.state;
+  }
+
+  close(): void {
+    this.lightbox.close();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.state().open) {
+      this.close();
+    }
+  }
+}

--- a/src/app/components/image-lightbox/image-lightbox.service.ts
+++ b/src/app/components/image-lightbox/image-lightbox.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface ImageLightboxState {
+  open: boolean;
+  src: string;
+  alt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ImageLightboxService {
+  readonly state = signal<ImageLightboxState>({ open: false, src: '', alt: '' });
+
+  open(src: string, alt: string): void {
+    this.state.set({ open: true, src, alt });
+  }
+
+  close(): void {
+    this.state.set({ open: false, src: '', alt: '' });
+  }
+}

--- a/src/app/components/module-card/module-card.component.html
+++ b/src/app/components/module-card/module-card.component.html
@@ -1,7 +1,8 @@
 <div class="bg-white shadow-md rounded-lg overflow-hidden">
-    <img 
-    [src]="module?.imageSrc" 
-    [alt]="module?.imageAlt" 
+    <img
+    appZoomable
+    [src]="module?.imageSrc"
+    [alt]="module?.imageAlt"
     class="w-full h-48 object-cover">
     <div class="p-4">
         <h2 class="text-xl font-semibold">{{module?.title}}</h2>

--- a/src/app/directives/zoomable.directive.ts
+++ b/src/app/directives/zoomable.directive.ts
@@ -1,0 +1,21 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+import { ImageLightboxService } from '../components/image-lightbox/image-lightbox.service';
+
+@Directive({
+  selector: 'img[appZoomable]',
+  standalone: false
+})
+export class ZoomableDirective {
+  constructor(
+    private readonly el: ElementRef<HTMLImageElement>,
+    private readonly lightbox: ImageLightboxService
+  ) {
+    this.el.nativeElement.classList.add('cursor-zoom-in');
+  }
+
+  @HostListener('click')
+  onClick(): void {
+    const img = this.el.nativeElement;
+    this.lightbox.open(img.src, img.alt);
+  }
+}

--- a/src/app/pages/member-directory-module-demo/member-directory-module-demo.component.html
+++ b/src/app/pages/member-directory-module-demo/member-directory-module-demo.component.html
@@ -1,7 +1,7 @@
 <main class="container mx-auto py-8">
     <p class="text-gray-600">Below is a live example of the module in action.</p>
     <div class="flex w-full justify-center py-5">
-        <img src="img/member-directory-module/member-directory-demo.gif" alt="Member Directory Module Demo" class="w-full md:w-3/4 lg:w-1/2">
+        <img appZoomable src="img/member-directory-module/member-directory-demo.gif" alt="Member Directory Module Demo" class="w-full md:w-3/4 lg:w-1/2">
     </div>
     
     <h2 class="text-2xl font-bold mt-8">Module Description</h2>

--- a/src/app/pages/member-directory-module-license/member-directory-module-license.component.html
+++ b/src/app/pages/member-directory-module-license/member-directory-module-license.component.html
@@ -1,12 +1,12 @@
 <div class="flex flex-col gap-10 p-5 sm:p-10">
   <div class="flex flex-col sm:flex-row items-center justify-center gap-5">
     <stripe-buy-button name="Member Directory Module - 1 Year License"
-      buy-button-id="buy_btn_1TC5j98x74qeNS0cs6zPY2QJ"
-      publishable-key="pk_live_51TC4Sa8x74qeNS0c1UXPQYjFikRT9rV8ENA0uZPDG9PdlzMibXTPPe8VCeJQBNCkMAzH5Jm9MNCdeAUySp5G7gSL003TkA19K8">
+      buy-button-id="buy_btn_1TbNjSQCWQgJswssGB5Ev8ro"
+      publishable-key="pk_live_51TbMpSQCWQgJswssK9djxyOpGuyB9bVsXhWE7jLFQzorSmEg8vN2uaLf04zkAbOKdZNYPIuNXIET3ZWkmdTbOBJp00gcRZF4Z6">
     </stripe-buy-button>
     <stripe-buy-button name="Member Directory Module - 1 Month Free Trial License"
-      buy-button-id="buy_btn_1TC5jd8x74qeNS0ckhq5z2ou"
-      publishable-key="pk_live_51TC4Sa8x74qeNS0c1UXPQYjFikRT9rV8ENA0uZPDG9PdlzMibXTPPe8VCeJQBNCkMAzH5Jm9MNCdeAUySp5G7gSL003TkA19K8">
+      buy-button-id="buy_btn_1TbNXoQCWQgJswssB3QAC6ik"
+      publishable-key="pk_live_51TbMpSQCWQgJswssK9djxyOpGuyB9bVsXhWE7jLFQzorSmEg8vN2uaLf04zkAbOKdZNYPIuNXIET3ZWkmdTbOBJp00gcRZF4Z6">
     </stripe-buy-button>
   </div>
 

--- a/src/app/pages/module-installation-guides/member-directory-instalation-guide/member-directory-instalation-guide.component.html
+++ b/src/app/pages/module-installation-guides/member-directory-instalation-guide/member-directory-instalation-guide.component.html
@@ -10,15 +10,15 @@
                     <ul>
                         <li >
                             Navigate to <strong>System</strong> &gt; <strong>Plugins</strong>
-                            <img src="img/joomla-admin-panel/system-plugins.png" alt="Joomla Admin Panel Plugins">
+                            <img appZoomable src="img/joomla-admin-panel/system-plugins.png" alt="Joomla Admin Panel Plugins">
                         </li>
                         <li>
                             Search for the <strong>User - Profile</strong> plugin and click on it.
-                            <img src="img/joomla-admin-panel/system-plugins-user_profile.png" alt="Joomla Admin Panel User Profile Plugin on Plugins List">
+                            <img appZoomable src="img/joomla-admin-panel/system-plugins-user_profile.png" alt="Joomla Admin Panel User Profile Plugin on Plugins List">
                         </li>
                         <li>
                             Make sure to have the <i>Status</i> set to <strong>Enabled</strong> and activate the fields you want to use.
-                            <img src="img/joomla-admin-panel/user-profile.png" alt="User - Profile Plugin Settings" class="img-fluid mt-2 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/user-profile.png" alt="User - Profile Plugin Settings" class="img-fluid mt-2 rounded-md shadow-md">
                         </li>
                         <li>
                             Click on <strong>Save & Close</strong> button to save your changes.
@@ -27,11 +27,11 @@
                 </li>        
                 <li>
                     Navigate to <strong>Content</strong> &gt; <strong>Site Modules</strong>, search the module and click on it.
-                    <img src="img/joomla-admin-panel/search-module.png" alt="Joomla Admin Panel Modules" class="img-fluid mt-4 rounded-md shadow-md">
+                    <img appZoomable src="img/joomla-admin-panel/search-module.png" alt="Joomla Admin Panel Modules" class="img-fluid mt-4 rounded-md shadow-md">
                 </li>
                 <li>
                     On <strong>Fields Configuration</strong> tab, you can add, edit, remove, or rearrange the fields as you like. Only the fields defined in Joomla's native 'User - Profile' plugin are supported.
-                    <img src="img/joomla-admin-panel/module-fields.png" alt="Joomla Admin Panel Module Fields" class="img-fluid mt-2 rounded-md shadow-md">
+                    <img appZoomable src="img/joomla-admin-panel/module-fields.png" alt="Joomla Admin Panel Module Fields" class="img-fluid mt-2 rounded-md shadow-md">
                     <p class="mt-2"> 
                         This module supports only fields declared in the native Joomla <strong>User - Profile</strong> plugin. 
                         <br>

--- a/src/app/pages/module-installation-guides/module-installation-guide/module-installation-guide.component.html
+++ b/src/app/pages/module-installation-guides/module-installation-guide/module-installation-guide.component.html
@@ -15,29 +15,29 @@
                         <li class="bg-gray-100 p-4 rounded-md">
                             Once the module downloaded, go to your Joomla admin panel, navigate to 
                             <strong>System</strong> &gt; <strong>Install</strong> &gt; <strong>Extensions</strong>.
-                            <img src="img/joomla-admin-panel/system-install-extensions.png" alt="Joomla Admin Panel System" class="img-fluid mt-4 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/system-install-extensions.png" alt="Joomla Admin Panel System" class="img-fluid mt-4 rounded-md shadow-md">
                         </li>
                         <li class="bg-gray-100 p-4 rounded-md">
                             Drag and drop or browse to the zip module you downloaded to install it.
-                            <img src="img/joomla-admin-panel/install-extensions.png" alt="Joomla Admin Panel Extensions Installation" class="img-fluid mt-4 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/install-extensions.png" alt="Joomla Admin Panel Extensions Installation" class="img-fluid mt-4 rounded-md shadow-md">
                         </li>
                     </ul>                    
                 </li>             
                 <li>
                     Navigate to <strong>Content</strong> &gt; <strong>Site Modules</strong>, search the module and click on it.
-                    <img src="img/joomla-admin-panel/search-module.png" alt="Joomla Admin Panel Modules" class="img-fluid mt-4 rounded-md shadow-md">
+                    <img appZoomable src="img/joomla-admin-panel/search-module.png" alt="Joomla Admin Panel Modules" class="img-fluid mt-4 rounded-md shadow-md">
                     <ul class="list-disc list-inside mt-4 space-y-4">
                         <li class="bg-gray-50 p-4 rounded-md">
                             On <strong>Module</strong> tab, make sure to have the <i>Position</i> and <i>Status</i> set to your preference.
-                            <img src="img/joomla-admin-panel/module-settings.png" alt="Joomla Admin Panel Module Settings" class="img-fluid mt-2 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/module-settings.png" alt="Joomla Admin Panel Module Settings" class="img-fluid mt-2 rounded-md shadow-md">
                         </li>
                         <li class="bg-gray-50 p-4 rounded-md">
                             On <strong>Menu Assignment</strong> tab, make sure to select the menu items where you want the module to appear.
-                            <img src="img/joomla-admin-panel/module-menu-assignment.png" alt="Joomla Admin Panel Module Menu Assignment" class="img-fluid mt-2 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/module-menu-assignment.png" alt="Joomla Admin Panel Module Menu Assignment" class="img-fluid mt-2 rounded-md shadow-md">
                         </li>
                         <li class="bg-gray-50 p-4 rounded-md">
                             On <strong>Subscription</strong> tab, fill in the required fields.
-                            <img src="img/joomla-admin-panel/module-subscription.png" alt="Joomla Admin Panel Module Subscription" class="img-fluid mt-2 rounded-md shadow-md">
+                            <img appZoomable src="img/joomla-admin-panel/module-subscription.png" alt="Joomla Admin Panel Module Subscription" class="img-fluid mt-2 rounded-md shadow-md">
                         </li>
                         <li>
                             Click on <strong>Save & Close</strong> button to save your changes.

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Premium Joomla modules and extensions. High-quality, multilingual, and customizable solutions for your Joomla website. Free trials available.">
     <meta name="keywords" content="joomla,modules,extensions,premium,multilingual,rtl,custom fields">
-    <link rel="icon" type="image/png" href="https://joomla.kabinary.com/favicon.png">
+    <link rel="icon" type="image/png" href="favicon.png">
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
     
     <!-- Google Analytics 4 -->


### PR DESCRIPTION
## Summary
- Updated Stripe `buy-button-id` and `publishable-key` to the new Kabinary account (1-year license + 1-month free trial)
- Added a reusable click-to-zoom lightbox on every site image (module cards, demo GIF, all installation-guide screenshots) — closeable via backdrop click, Esc key, or X button
- Applied `min-h-screen` + `flex-1` `<main>` wrapper so the footer no longer leaves an empty white area on short pages
- Switched favicon `<link>` from external URL to relative path `favicon.png`
- Updated footer copyright text to "Kabinary LLC"

## Test plan
- [ ] Visit `/member-directory-module-license` → buttons load the new Stripe checkout flows
- [ ] Click any image (home cards, demo, installation guides) → lightbox opens; test all three close methods
- [ ] Resize to mobile viewport → footer stays at bottom on short pages, screenshots become readable via lightbox
- [ ] Inspect favicon network request → served from same origin (no `joomla.kabinary.com`)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)