### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Pas de target-branch : ce repo n'a pas de branche develop, les PR vont sur main.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      # Angular publie core / cli / build-angular sur la même cadence et les
+      # peer deps se pinnent mutuellement. Les grouper évite les PR qui
+      # échouent isolément sur un conflit de peer dependency.
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular/build"
+          - "typescript"
+          - "tslib"
+          - "zone.js"
+      # Catch-all : minor + patch dans une seule PR. Les majeures restent
+      # individuelles pour être relues à la main.
+      minor-and-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "typescript"
+          - "tslib"
+          - "zone.js"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Contexte

Le repo n'avait aucun `dependabot.yml` alors que les alertes de sécurité étaient déjà actives : les vulnérabilités étaient détectées, mais rien n'ouvrait de PR pour les corriger.

## Contenu

Configuration npm avec regroupement de la toolchain Angular — `@angular/core`, `@angular/cli` et `@angular-devkit/build-angular` partagent la même cadence de release et se pinnent mutuellement via leurs peer deps ; les grouper évite les PR qui échouent isolément sur un conflit.

Le catch-all `minor-and-patch` bundle le reste en une PR ; les majeures restent individuelles pour être relues à la main.

Pas de `target-branch` : ce repo n'a pas de branche `develop`, les PR vont sur `main`.

> À noter : Dependabot ne lit `dependabot.yml` que sur la branche par défaut. Ce fichier doit donc être mergé sur `main` pour prendre effet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)