### PR TITLE
fix(tests): declare component dependencies in specs

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,16 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from './app.module';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        RouterModule.forRoot([])
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [AppModule, RouterTestingModule, RouterModule.forRoot([])],
     }).compileComponents();
   });
 

--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ButtonComponent } from './button.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -8,7 +10,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ButtonComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/components/collapsible-panel/collapsible-panel.component.spec.ts
+++ b/src/app/components/collapsible-panel/collapsible-panel.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CollapsiblePanelComponent } from './collapsible-panel.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('CollapsiblePanelComponent', () => {
   let component: CollapsiblePanelComponent;
@@ -8,7 +10,7 @@ describe('CollapsiblePanelComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [CollapsiblePanelComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FooterComponent } from './footer.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -8,7 +10,7 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [FooterComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeaderComponent } from './header.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -8,7 +10,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HeaderComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/components/module-card/module-card.component.spec.ts
+++ b/src/app/components/module-card/module-card.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModuleCardComponent } from './module-card.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('ModuleCardComponent', () => {
   let component: ModuleCardComponent;
@@ -8,7 +10,7 @@ describe('ModuleCardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ModuleCardComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -8,7 +10,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HomeComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/pages/member-directory-module-demo/member-directory-module-demo.component.spec.ts
+++ b/src/app/pages/member-directory-module-demo/member-directory-module-demo.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MemberDirectoryModuleDemoComponent } from './member-directory-module-demo.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('MemberDirectoryModuleDemoComponent', () => {
   let component: MemberDirectoryModuleDemoComponent;
@@ -8,7 +10,7 @@ describe('MemberDirectoryModuleDemoComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MemberDirectoryModuleDemoComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/pages/member-directory-module-license/member-directory-module-license.component.spec.ts
+++ b/src/app/pages/member-directory-module-license/member-directory-module-license.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MemberDirectoryModuleLicenseComponent } from './member-directory-module-license.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../app.module';
 
 describe('MemberDirectoryModuleLicenseComponent', () => {
   let component: MemberDirectoryModuleLicenseComponent;
@@ -8,7 +10,7 @@ describe('MemberDirectoryModuleLicenseComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MemberDirectoryModuleLicenseComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/pages/module-installation-guides/member-directory-instalation-guide/member-directory-instalation-guide.component.spec.ts
+++ b/src/app/pages/module-installation-guides/member-directory-instalation-guide/member-directory-instalation-guide.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MemberDirectoryInstalationGuideComponent } from './member-directory-instalation-guide.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../../app.module';
 
 describe('MemberDirectoryInstalationGuideComponent', () => {
   let component: MemberDirectoryInstalationGuideComponent;
@@ -8,7 +10,7 @@ describe('MemberDirectoryInstalationGuideComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MemberDirectoryInstalationGuideComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 

--- a/src/app/pages/module-installation-guides/module-installation-guide/module-installation-guide.component.spec.ts
+++ b/src/app/pages/module-installation-guides/module-installation-guide/module-installation-guide.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModuleInstallationGuideComponent } from './module-installation-guide.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppModule } from '../../../app.module';
 
 describe('ModuleInstallationGuideComponent', () => {
   let component: ModuleInstallationGuideComponent;
@@ -8,7 +10,7 @@ describe('ModuleInstallationGuideComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ModuleInstallationGuideComponent]
+      imports: [AppModule, RouterTestingModule]
     })
     .compileComponents();
 


### PR DESCRIPTION
## Le problème

**11 des 13 tests échouaient sur `main`**, indépendamment de toute mise à jour de dépendance :

```
NG0304: 'app-button' is not a known element
NG0303: Can't bind to 'routerLink' since it isn't a known property of 'a'
NG0304: 'app-collapsible-panel' is not a known element
NG0304: 'app-module-installation-guide' is not a known element
```

## La cause

Les specs générées par `ng generate` ne déclarent **que le composant testé** :

```ts
TestBed.configureTestingModule({
  declarations: [MemberDirectoryModuleDemoComponent]
})
```

Dès que son template utilise un autre composant du projet (`app-button`…) ou une directive de routage (`routerLink`), le TestBed ne sait pas les résoudre.

## La correction

Chaque spec importe désormais `AppModule` — qui déclare tous les composants — et `RouterTestingModule` pour les directives de routage :

```ts
TestBed.configureTestingModule({
  imports: [AppModule, RouterTestingModule]
})
```

**Cas particulier** : `app.component.spec.ts` avait déjà un bloc `imports` avec `RouterModule.forRoot([])`. Les deux ont été fusionnés en une seule clé — deux clés `imports` dans le même objet faisaient échouer le chargement de Karma (`Found 1 load error`).

## Vérification

```
Executed 13 of 13 SUCCESS
```

**13 tests sur 13 passent** (11 échouaient). Build de production → **OK**.

Ce correctif est indépendant des mises à jour Dependabot : il répare un défaut structurel des specs, présent depuis leur génération.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
