### PR TITLE
chore(deps): ignore TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Angular déclare peerDependencies.typescript ">=6.0 <6.1" jusque dans
+      # ses préversions 22.2.0-next. Forcé en TypeScript 7, le compilateur
+      # Angular plante : TypeError: Cannot read properties of undefined.
+      # À retirer quand Angular supportera TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Pourquoi

Angular déclare `peerDependencies.typescript: ">=6.0 <6.1"` — **y compris dans ses préversions `22.2.0-next`**. Aucune version d'Angular, stable ou non, ne supporte TypeScript 7 à ce jour.

## Ce n'est pas qu'un refus déclaratif

Forcé en TypeScript 7 avec `--legacy-peer-deps` (test mené sur `cms-modules-fe`), le compilateur Angular ne se contente pas d'avertir — **il plante** :

```
Application bundle generation failed. [0.245 seconds]
  TypeError: Cannot read properties of undefined (reading 'Error')
```

L'API interne de TypeScript a changé. Aucun contournement n'est possible : il faut attendre qu'Angular publie une version compatible.

## Portée

`version-update:semver-major` uniquement — les correctifs de sécurité sur TypeScript 6.x continuent d'être proposés normalement.

**À retirer** quand Angular supportera TypeScript 7.

> Note : ce bump passe sans problème sur `facemento-fe` (React/Vite), qui n'a pas cette contrainte — il y a d'ailleurs été mergé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
